### PR TITLE
Add .env configuration support and test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.env.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: test
+
+TEST_CMD ?= pytest -q
+
+test:
+	$(TEST_CMD)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Raspberry-Pi-5-2
+
+## 測試指令
+
+- `make test`：使用預設的 pytest 指令快速驗證程式碼。
+- `pytest -q`：直接執行測試套件，適合 CI 或手動檢查。
+
+## .env 設定支援
+
+主程式 `face_recognition_ad_system.py` 現在會自動讀取 `.env` 檔案，
+可透過以下環境變數覆寫預設值：
+
+- FACE_AD_DB_HOST / DB_HOST
+- FACE_AD_DB_USER / DB_USER
+- FACE_AD_DB_PASSWORD / DB_PASSWORD
+- FACE_AD_DB_NAME / DB_NAME
+- FACE_AD_DB_PORT / DB_PORT
+- FACE_AD_CAMERA_SOURCE / CAMERA_SOURCE
+- FACE_AD_CAMERA_WIDTH / CAMERA_WIDTH
+- FACE_AD_CAMERA_HEIGHT / CAMERA_HEIGHT
+- FACE_AD_CAMERA_FPS / CAMERA_FPS
+- FACE_AD_RECOGNITION_TOLERANCE / RECOGNITION_TOLERANCE
+- FACE_AD_RECOGNITION_MODEL / RECOGNITION_MODEL
+
+將 `.env` 檔案放在專案根目錄即可被自動載入，也可以透過
+環境變數 `FACE_AD_ENV_FILE` 指定不同位置的設定檔。

--- a/facecam.py
+++ b/facecam.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""facecam.py - 即時人臉辨識
+
+此模組提供樹莓派、Jetson Nano 及 Windows 等平台使用的即時人臉辨識工具，
+可將由 :mod:`facegen` 產生的人臉編碼載入後，透過攝影機或靜態圖片進行辨識。
+
+功能特色
+---------
+* 支援 USB 攝影機、樹莓派 CSI 攝影機或 GStreamer 管線
+* 內建影像縮放加速機制，適合在資源受限裝置上使用
+* 可於命令列指定靜態圖片進行辨識
+* 透過 CSV 檔案載入既有人臉編碼
+* 可輸出辨識結果（名稱與信心度）
+
+範例::
+
+    # 使用預設攝影機進行即時辨識
+    python facecam.py --encodings encodings.csv
+
+    # 指定圖片檔案進行辨識
+    python facecam.py --encodings encodings.csv --image ./test.jpg
+
+    # 指定相機來源與縮放倍率
+    python facecam.py --encodings encodings.csv --video-source 1 --scale 0.33
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import platform
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
+
+import cv2
+import numpy as np
+
+try:
+    import face_recognition
+except ImportError as exc:  # pragma: no cover - 執行環境缺套件時才觸發
+    raise ImportError(
+        "facecam.py 需要 face_recognition 套件，請先安裝：pip install face-recognition"
+    ) from exc
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class RecognizedFace:
+    """儲存單一人臉辨識結果。"""
+
+    name: str
+    location: Tuple[int, int, int, int]
+    distance: float
+
+    @property
+    def confidence(self) -> float:
+        """依據距離推估的信心度 (0.0~1.0)。"""
+
+        # face_recognition 距離範圍大約 0.0 ~ 1.0，值越小表示越相似
+        return float(np.clip(1.0 - self.distance, 0.0, 1.0))
+
+
+class KnownFacesStore:
+    """管理已知人臉編碼的輔助類別。"""
+
+    def __init__(self, tolerance: float = 0.6) -> None:
+        self.tolerance = tolerance
+        self.encodings: List[np.ndarray] = []
+        self.labels: List[str] = []
+
+    # ------------------------------------------------------------------
+    def load_from_csv(self, csv_path: Path) -> None:
+        csv_path = csv_path.expanduser().resolve()
+        if not csv_path.exists():
+            raise FileNotFoundError(f"找不到編碼檔案: {csv_path}")
+
+        with csv_path.open("r", newline="", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                encoding = np.array(json.loads(row["encoding"]), dtype="float32")
+                self.encodings.append(encoding)
+                self.labels.append(row["label"])
+        LOGGER.info("載入 %d 筆已知人臉資料", len(self.labels))
+
+    # ------------------------------------------------------------------
+    def recognize(self, face_encoding: np.ndarray) -> RecognizedFace:
+        if not self.encodings:
+            return RecognizedFace(name="Unknown", location=(0, 0, 0, 0), distance=1.0)
+
+        distances = face_recognition.face_distance(self.encodings, face_encoding)
+        best_index = int(np.argmin(distances))
+        name = "Unknown"
+        distance = float(distances[best_index])
+        if distance <= self.tolerance:
+            name = self.labels[best_index]
+        return RecognizedFace(name=name, location=(0, 0, 0, 0), distance=distance)
+
+
+class FaceRecognitionCamera:
+    """即時人臉辨識引擎。"""
+
+    def __init__(
+        self,
+        encodings_store: KnownFacesStore,
+        scale: float = 0.25,
+        model: str = "hog",
+        frame_skip: int = 1,
+    ) -> None:
+        self.encodings_store = encodings_store
+        self.scale = max(0.1, min(scale, 1.0))
+        self.model = model
+        self.frame_skip = max(1, int(frame_skip))
+
+    # ------------------------------------------------------------------
+    def recognize_frame(self, frame: np.ndarray) -> List[RecognizedFace]:
+        """對單張影格執行人臉辨識。"""
+
+        small_frame = cv2.resize(frame, (0, 0), fx=self.scale, fy=self.scale)
+        rgb_small_frame = cv2.cvtColor(small_frame, cv2.COLOR_BGR2RGB)
+
+        face_locations = face_recognition.face_locations(rgb_small_frame, model=self.model)
+        face_encodings = face_recognition.face_encodings(rgb_small_frame, face_locations)
+
+        results: List[RecognizedFace] = []
+        for location, encoding in zip(face_locations, face_encodings):
+            recognized = self.encodings_store.recognize(encoding)
+            top, right, bottom, left = location
+            scale_factor = 1.0 / self.scale
+            scaled_location = (
+                int(top * scale_factor),
+                int(right * scale_factor),
+                int(bottom * scale_factor),
+                int(left * scale_factor),
+            )
+            results.append(
+                RecognizedFace(
+                    name=recognized.name,
+                    location=scaled_location,
+                    distance=recognized.distance,
+                )
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    def draw_annotations(self, frame: np.ndarray, results: Iterable[RecognizedFace]) -> np.ndarray:
+        for result in results:
+            top, right, bottom, left = result.location
+            cv2.rectangle(frame, (left, top), (right, bottom), (0, 0, 255), 2)
+            label = f"{result.name} ({result.confidence*100:.1f}%)"
+            cv2.rectangle(frame, (left, bottom - 25), (right, bottom), (0, 0, 255), cv2.FILLED)
+            cv2.putText(
+                frame,
+                label,
+                (left + 6, bottom - 6),
+                cv2.FONT_HERSHEY_DUPLEX,
+                0.5,
+                (255, 255, 255),
+                1,
+            )
+        return frame
+
+    # ------------------------------------------------------------------
+    def run_camera(
+        self,
+        video_source: Union[int, str] = 0,
+        window_name: str = "FaceCam",
+        display: bool = True,
+        output_path: Optional[Path] = None,
+    ) -> None:
+        capture = self._create_capture(video_source)
+        if not capture or not capture.isOpened():
+            raise RuntimeError(f"無法開啟攝影機來源: {video_source}")
+
+        writer: Optional[cv2.VideoWriter] = None
+        if output_path is not None:
+            fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+            fps = capture.get(cv2.CAP_PROP_FPS) or 15
+            frame_width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+            frame_height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+            writer = cv2.VideoWriter(str(output_path), fourcc, fps, (frame_width, frame_height))
+
+        frame_index = 0
+        while True:
+            ret, frame = capture.read()
+            if not ret:
+                LOGGER.warning("攝影機回傳空影格，結束辨識")
+                break
+
+            frame_index += 1
+            if frame_index % self.frame_skip != 0:
+                if display:
+                    cv2.imshow(window_name, frame)
+                    if cv2.waitKey(1) & 0xFF == ord("q"):
+                        break
+                if writer:
+                    writer.write(frame)
+                continue
+
+            results = self.recognize_frame(frame)
+            annotated = self.draw_annotations(frame.copy(), results)
+
+            for result in results:
+                LOGGER.debug("偵測到 %s (confidence=%.2f)", result.name, result.confidence)
+
+            if display:
+                cv2.imshow(window_name, annotated)
+                if cv2.waitKey(1) & 0xFF == ord("q"):
+                    break
+
+            if writer:
+                writer.write(annotated)
+
+        capture.release()
+        if writer:
+            writer.release()
+        if display:
+            cv2.destroyWindow(window_name)
+
+    # ------------------------------------------------------------------
+    def recognize_image(self, image_path: Path) -> List[RecognizedFace]:
+        image_path = image_path.expanduser().resolve()
+        if not image_path.exists():
+            raise FileNotFoundError(f"找不到圖片檔案: {image_path}")
+        frame = cv2.imread(str(image_path))
+        if frame is None:
+            raise RuntimeError(f"無法讀取圖片: {image_path}")
+        return self.recognize_frame(frame)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _create_capture(source: Union[int, str]) -> cv2.VideoCapture:
+        system = platform.system()
+        if isinstance(source, str) and not source.isdigit():
+            LOGGER.info("使用 GStreamer 管線: %s", source)
+            return cv2.VideoCapture(source, cv2.CAP_GSTREAMER)
+
+        try:
+            index = int(source)
+        except (TypeError, ValueError):
+            index = 0
+
+        if system == "Windows":
+            return cv2.VideoCapture(index, cv2.CAP_DSHOW)
+        if system == "Linux":
+            return cv2.VideoCapture(index, cv2.CAP_V4L2)
+        return cv2.VideoCapture(index)
+
+
+# ----------------------------------------------------------------------
+# 命令列處理
+# ----------------------------------------------------------------------
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="即時人臉辨識工具")
+    parser.add_argument("--encodings", required=True, help="facegen 產生的編碼 CSV 檔")
+    parser.add_argument("--video-source", default="0", help="攝影機來源索引或 GStreamer 字串")
+    parser.add_argument("--image", help="指定圖片檔案進行辨識")
+    parser.add_argument("--scale", type=float, default=0.25, help="辨識前的影像縮放比例 (0~1)")
+    parser.add_argument("--tolerance", type=float, default=0.6, help="辨識容忍度，值越小越嚴格")
+    parser.add_argument("--model", choices=["hog", "cnn"], default="hog", help="人臉偵測模型")
+    parser.add_argument("--frame-skip", type=int, default=1, help="處理時跳過的影格數，可降低運算負擔")
+    parser.add_argument("--output", help="將辨識結果錄製為影片檔")
+    parser.add_argument("--no-display", action="store_true", help="不顯示影像（適合遠端或無螢幕環境）")
+    parser.add_argument("--log-level", default="INFO", help="記錄器等級，例如 INFO、DEBUG")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    store = KnownFacesStore(tolerance=args.tolerance)
+    store.load_from_csv(Path(args.encodings))
+
+    engine = FaceRecognitionCamera(
+        encodings_store=store,
+        scale=args.scale,
+        model=args.model,
+        frame_skip=args.frame_skip,
+    )
+
+    if args.image:
+        results = engine.recognize_image(Path(args.image))
+        if not results:
+            print("未偵測到任何人臉")
+        else:
+            for result in results:
+                print(f"{result.name}\tconfidence={result.confidence:.2f}")
+        return 0
+
+    output_path = Path(args.output) if args.output else None
+    engine.run_camera(
+        video_source=args.video_source,
+        window_name="Face Recognition",
+        display=not args.no_display,
+        output_path=output_path,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - 命令列執行點
+    raise SystemExit(main())

--- a/facegen.py
+++ b/facegen.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""facegen.py - 人臉編碼生成器
+
+此模組負責將靜態人臉圖片轉換為可儲存的人臉特徵向量，
+支援單一圖片或整個資料夾的批次處理，並可匯出為 CSV 檔案。
+
+範例使用方式::
+
+    # 由單一圖片產生人臉編碼
+    python facegen.py --input ./images/alice.jpg --label Alice --output encodings.csv
+
+    # 批次處理整個資料夾，並根據資料夾名稱當作標籤
+    python facegen.py --input ./dataset --recursive --output encodings.csv
+
+本模組也可於其他程式中匯入使用::
+
+    from facegen import FaceEncodingGenerator
+
+    generator = FaceEncodingGenerator(model="hog")
+    records = generator.process_directory("./dataset")
+    generator.save_to_csv(records, "encodings.csv")
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Sequence
+
+try:
+    import face_recognition
+except ImportError as exc:  # pragma: no cover - 環境未安裝套件時才會執行
+    raise ImportError(
+        "facegen.py 需要 face_recognition 套件，請先安裝：pip install face-recognition"
+    ) from exc
+
+LOGGER = logging.getLogger(__name__)
+SUPPORTED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff"}
+
+
+@dataclass
+class FaceEncodingRecord:
+    """代表一筆人臉編碼資料。"""
+
+    label: str
+    file_path: str
+    encoding: Sequence[float]
+
+    def to_csv_row(self) -> List[str]:
+        """轉換為可寫入 CSV 的列資料。"""
+
+        return [self.label, self.file_path, json.dumps(list(self.encoding))]
+
+
+class FaceEncodingGenerator:
+    """將影像資料轉換為人臉特徵向量的工具類別。"""
+
+    def __init__(
+        self,
+        model: str = "hog",
+        upsample_times: int = 1,
+        num_jitters: int = 1,
+        allow_multiple_faces: bool = False,
+    ) -> None:
+        """初始化編碼器。
+
+        Args:
+            model: face_recognition 使用的偵測模型，`"hog"` 或 `"cnn"`。
+            upsample_times: 偵測人臉時影像上採樣次數。
+            num_jitters: 人臉編碼抖動次數，可提升精準度但增加運算量。
+            allow_multiple_faces: 是否在單張圖片上儲存多張人臉編碼。
+        """
+
+        self.model = model
+        self.upsample_times = max(0, int(upsample_times))
+        self.num_jitters = max(1, int(num_jitters))
+        self.allow_multiple_faces = allow_multiple_faces
+
+    # ------------------------------------------------------------------
+    # 影像處理邏輯
+    # ------------------------------------------------------------------
+    def process_image(self, image_path: Path, label: Optional[str] = None) -> List[FaceEncodingRecord]:
+        """處理單一影像並回傳人臉編碼紀錄列表。"""
+
+        image_path = image_path.expanduser().resolve()
+        LOGGER.debug("Processing image: %s", image_path)
+
+        if not image_path.exists():
+            raise FileNotFoundError(f"影像檔案不存在: {image_path}")
+
+        image = face_recognition.load_image_file(str(image_path))
+        face_locations = face_recognition.face_locations(
+            image,
+            number_of_times_to_upsample=self.upsample_times,
+            model=self.model,
+        )
+
+        if not face_locations:
+            LOGGER.warning("未在圖片 %s 偵測到人臉", image_path)
+            return []
+
+        encodings = face_recognition.face_encodings(
+            image,
+            known_face_locations=face_locations,
+            num_jitters=self.num_jitters,
+        )
+
+        records: List[FaceEncodingRecord] = []
+        for index, encoding in enumerate(encodings):
+            if not self.allow_multiple_faces and index > 0:
+                LOGGER.info("圖片 %s 偵測到多張人臉，只保留第一張", image_path)
+                break
+
+            encoding_label = label or self._infer_label(image_path, index)
+            records.append(
+                FaceEncodingRecord(
+                    label=encoding_label,
+                    file_path=str(image_path),
+                    encoding=encoding.tolist(),
+                )
+            )
+
+        LOGGER.info("圖片 %s 產生 %d 筆編碼", image_path, len(records))
+        return records
+
+    def process_directory(
+        self,
+        directory: Path,
+        recursive: bool = True,
+        label_from_parent: bool = True,
+    ) -> Iterator[FaceEncodingRecord]:
+        """批次處理整個資料夾並回傳紀錄產生器。"""
+
+        directory = directory.expanduser().resolve()
+        if not directory.exists():
+            raise FileNotFoundError(f"資料夾不存在: {directory}")
+
+        pattern = "**/*" if recursive else "*"
+        for path in sorted(directory.glob(pattern)):
+            if not path.is_file() or path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+                continue
+
+            label = path.parent.name if label_from_parent else path.stem
+            for record in self.process_image(path, label=label):
+                yield record
+
+    def generate_from_path(
+        self,
+        input_path: Path,
+        recursive: bool = True,
+        label: Optional[str] = None,
+    ) -> List[FaceEncodingRecord]:
+        """根據輸入路徑（檔案或資料夾）產生人臉編碼紀錄。"""
+
+        input_path = input_path.expanduser()
+        if input_path.is_file():
+            return self.process_image(input_path, label=label)
+        if input_path.is_dir():
+            return list(self.process_directory(input_path, recursive=recursive))
+        raise FileNotFoundError(f"找不到指定的輸入路徑: {input_path}")
+
+    # ------------------------------------------------------------------
+    # 輸出與資料儲存
+    # ------------------------------------------------------------------
+    @staticmethod
+    def save_to_csv(
+        records: Iterable[FaceEncodingRecord],
+        output_path: Path,
+        append: bool = False,
+    ) -> int:
+        """將編碼結果儲存為 CSV 檔案。
+
+        Args:
+            records: 可迭代的 :class:`FaceEncodingRecord` 物件。
+            output_path: 輸出檔案路徑。
+            append: 若為 ``True`` 則採附加模式，否則覆寫檔案。
+
+        Returns:
+            寫入的紀錄數量。
+        """
+
+        output_path = output_path.expanduser().resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        mode = "a" if append and output_path.exists() else "w"
+        count = 0
+        with output_path.open(mode, newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            if mode == "w":
+                writer.writerow(["label", "file_path", "encoding"])
+
+            for record in records:
+                writer.writerow(record.to_csv_row())
+                count += 1
+
+        LOGGER.info("已將 %d 筆資料寫入 %s", count, output_path)
+        return count
+
+    @staticmethod
+    def load_from_csv(csv_path: Path) -> List[FaceEncodingRecord]:
+        """從既有的 CSV 檔案載入人臉編碼資料。"""
+
+        csv_path = csv_path.expanduser().resolve()
+        if not csv_path.exists():
+            raise FileNotFoundError(f"找不到 CSV 檔案: {csv_path}")
+
+        records: List[FaceEncodingRecord] = []
+        with csv_path.open("r", newline="", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                encoding = json.loads(row["encoding"])
+                records.append(
+                    FaceEncodingRecord(
+                        label=row["label"],
+                        file_path=row["file_path"],
+                        encoding=encoding,
+                    )
+                )
+        LOGGER.debug("從 %s 載入 %d 筆資料", csv_path, len(records))
+        return records
+
+    # ------------------------------------------------------------------
+    # 工具方法
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _infer_label(image_path: Path, index: int) -> str:
+        """依據檔名推論標籤。"""
+
+        if index == 0:
+            return image_path.stem
+        return f"{image_path.stem}_{index}"
+
+
+# ----------------------------------------------------------------------
+# 命令列介面
+# ----------------------------------------------------------------------
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="人臉編碼生成工具")
+    parser.add_argument("--input", required=True, help="圖片檔案或資料夾路徑")
+    parser.add_argument("--output", default="encodings.csv", help="輸出 CSV 檔案路徑")
+    parser.add_argument("--label", help="單張圖片的標籤名稱")
+    parser.add_argument("--model", default="hog", choices=["hog", "cnn"], help="人臉偵測模型")
+    parser.add_argument("--upsample", type=int, default=1, help="偵測人臉時的上採樣次數")
+    parser.add_argument("--jitters", type=int, default=1, help="產生人臉編碼時的抖動次數")
+    parser.add_argument("--allow-multi", action="store_true", help="允許單張圖片儲存多張人臉")
+    parser.add_argument("--recursive", action="store_true", help="遞迴處理子資料夾")
+    parser.add_argument("--append", action="store_true", help="以附加模式寫入 CSV")
+    parser.add_argument("--log-level", default="INFO", help="記錄器等級，例如 INFO 或 DEBUG")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    generator = FaceEncodingGenerator(
+        model=args.model,
+        upsample_times=args.upsample,
+        num_jitters=args.jitters,
+        allow_multiple_faces=args.allow_multi,
+    )
+
+    input_path = Path(args.input)
+    records = generator.generate_from_path(input_path, recursive=args.recursive, label=args.label)
+
+    if not records:
+        LOGGER.warning("沒有產生任何人臉編碼，請確認輸入資料")
+        return 1
+
+    output_path = Path(args.output)
+    FaceEncodingGenerator.save_to_csv(records, output_path, append=args.append)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - 命令列執行點
+    raise SystemExit(main())

--- a/faceme.py
+++ b/faceme.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""faceme.py - 人臉註冊介面
+
+提供友善的圖形化介面，協助管理員使用攝影機即時預覽並將人臉資料
+儲存至資料庫與本地資料集。此程式可與 :mod:`facegen`、:mod:`facecam`
+及 :mod:`rollcall_edge` 等模組共同使用。
+
+功能重點
+--------
+* 即時攝影機預覽，於畫面中顯示偵測到的人臉框
+* 支援輸入會員姓名、性別、年齡層等資訊
+* 自動將擷取的圖片與人臉編碼儲存至本地資料集 (CSV + 影像檔)
+* 可選擇性地寫入 MySQL 資料庫 (若環境支援)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import cv2
+import face_recognition
+from PIL import Image, ImageTk
+
+try:  # MySQL 為選用元件
+    import mysql.connector
+except Exception:  # pragma: no cover - 於無 MySQL 套件時觸發
+    mysql = None  # type: ignore[assignment]
+else:  # pragma: no cover - 測試環境無法驗證
+    mysql = mysql.connector
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from facegen import FaceEncodingGenerator, FaceEncodingRecord
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = Path("config.json")
+DATASET_DIR = Path("dataset")
+ENCODINGS_CSV = Path("encodings.csv")
+
+
+@dataclass
+class MemberInfo:
+    name: str
+    gender: Optional[str]
+    age_group: Optional[str]
+    email: Optional[str]
+
+
+class DatabaseManager:
+    """簡易的 MySQL 操作封裝。"""
+
+    def __init__(self, config_path: Path = DEFAULT_CONFIG_PATH) -> None:
+        self.config_path = config_path
+        self.connection: Optional[mysql.connection.MySQLConnection] = None  # type: ignore[attr-defined]
+        self.config = self._load_config()
+
+    def _load_config(self) -> dict:
+        if not self.config_path.exists():
+            LOGGER.warning("找不到設定檔 %s，將僅使用本地模式", self.config_path)
+            return {}
+        with self.config_path.open("r", encoding="utf-8") as fp:
+            return json.load(fp)
+
+    def connect(self) -> None:
+        if mysql is None:
+            LOGGER.warning("環境未安裝 mysql-connector-python，僅儲存至本地資料集")
+            return
+        if not self.config:
+            return
+        try:
+            self.connection = mysql.connect(**self.config.get("database", {}))
+        except Exception as exc:  # pragma: no cover - 資料庫連線錯誤較難模擬
+            LOGGER.error("資料庫連線失敗: %s", exc)
+            messagebox.showwarning("資料庫連線失敗", str(exc))
+            self.connection = None
+
+    def close(self) -> None:
+        if self.connection:
+            self.connection.close()
+            self.connection = None
+
+    def insert_member(self, member: MemberInfo, encoding: FaceEncodingRecord) -> Optional[int]:
+        if not self.connection:
+            return None
+        cursor = self.connection.cursor()
+        query = (
+            "INSERT INTO members (name, gender, age_group, email, face_encoding) "
+            "VALUES (%s, %s, %s, %s, %s)"
+        )
+        encoding_json = encoding.to_csv_row()[2]
+        cursor.execute(
+            query,
+            (
+                member.name,
+                member.gender,
+                member.age_group,
+                member.email,
+                encoding_json,
+            ),
+        )
+        self.connection.commit()
+        member_id = cursor.lastrowid
+        cursor.close()
+        return int(member_id)
+
+
+class FaceDatasetManager:
+    """負責管理本地影像資料與人臉編碼檔案。"""
+
+    def __init__(self, dataset_dir: Path = DATASET_DIR, csv_path: Path = ENCODINGS_CSV) -> None:
+        self.dataset_dir = dataset_dir
+        self.csv_path = csv_path
+        self.dataset_dir.mkdir(parents=True, exist_ok=True)
+
+    def save_face_image(self, label: str, frame: cv2.Mat) -> Path:
+        person_dir = self.dataset_dir / label
+        person_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = person_dir / f"{timestamp}.jpg"
+        cv2.imwrite(str(filename), frame)
+        return filename
+
+    def append_encoding(self, record: FaceEncodingRecord) -> None:
+        FaceEncodingGenerator.save_to_csv([record], self.csv_path, append=True)
+
+    def existing_labels(self) -> list[str]:
+        if not self.csv_path.exists():
+            return []
+        records = FaceEncodingGenerator.load_from_csv(self.csv_path)
+        return sorted({rec.label for rec in records})
+
+
+class FaceRegistrationApp:
+    """Tkinter 人臉註冊應用程式。"""
+
+    def __init__(
+        self,
+        config_path: Path = DEFAULT_CONFIG_PATH,
+        dataset_dir: Path = DATASET_DIR,
+        csv_path: Path = ENCODINGS_CSV,
+    ) -> None:
+        logging.basicConfig(level=logging.INFO)
+        self.root = tk.Tk()
+        self.root.title("人臉註冊系統")
+        self.root.geometry("960x640")
+
+        self.db_manager = DatabaseManager(config_path)
+        self.db_manager.connect()
+        self.dataset_manager = FaceDatasetManager(dataset_dir, csv_path)
+
+        self.camera = self._open_camera()
+        self.current_frame: Optional[cv2.Mat] = None
+
+        self._build_gui()
+        self._update_camera_frame()
+
+    # ------------------------------------------------------------------
+    def _open_camera(self) -> cv2.VideoCapture:
+        config = self.db_manager.config.get("camera", {}) if self.db_manager else {}
+        capture = cv2.VideoCapture(0)
+        if capture.isOpened():
+            if width := config.get("width"):
+                capture.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+            if height := config.get("height"):
+                capture.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+        else:
+            messagebox.showerror("攝影機錯誤", "無法開啟攝影機，請確認連線")
+        return capture
+
+    # ------------------------------------------------------------------
+    def _build_gui(self) -> None:
+        self.root.columnconfigure(0, weight=3)
+        self.root.columnconfigure(1, weight=2)
+        self.root.rowconfigure(0, weight=1)
+
+        # 攝影機預覽
+        preview_frame = ttk.LabelFrame(self.root, text="攝影機預覽", padding=10)
+        preview_frame.grid(row=0, column=0, sticky="nsew", padx=10, pady=10)
+
+        self.video_label = ttk.Label(preview_frame, text="等待攝影機...", anchor="center")
+        self.video_label.pack(fill="both", expand=True)
+
+        # 控制面板
+        control_frame = ttk.LabelFrame(self.root, text="會員資訊", padding=10)
+        control_frame.grid(row=0, column=1, sticky="nsew", padx=10, pady=10)
+        control_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(control_frame, text="姓名").grid(row=0, column=0, sticky="w")
+        self.name_var = tk.StringVar()
+        ttk.Entry(control_frame, textvariable=self.name_var).grid(row=0, column=1, sticky="ew")
+
+        ttk.Label(control_frame, text="性別").grid(row=1, column=0, sticky="w", pady=5)
+        self.gender_var = tk.StringVar()
+        gender_combo = ttk.Combobox(control_frame, textvariable=self.gender_var, state="readonly")
+        gender_combo["values"] = ("", "M", "F")
+        gender_combo.grid(row=1, column=1, sticky="ew")
+
+        ttk.Label(control_frame, text="年齡層").grid(row=2, column=0, sticky="w")
+        self.age_var = tk.StringVar()
+        age_combo = ttk.Combobox(control_frame, textvariable=self.age_var, state="readonly")
+        age_combo["values"] = ("", "18-25", "26-35", "36-45", "46-55", "56-65", "65+")
+        age_combo.grid(row=2, column=1, sticky="ew")
+
+        ttk.Label(control_frame, text="電子郵件").grid(row=3, column=0, sticky="w")
+        self.email_var = tk.StringVar()
+        ttk.Entry(control_frame, textvariable=self.email_var).grid(row=3, column=1, sticky="ew")
+
+        ttk.Label(control_frame, text="既有標籤").grid(row=4, column=0, sticky="nw", pady=(20, 5))
+        self.label_list = tk.Listbox(control_frame, height=6)
+        self.label_list.grid(row=4, column=1, sticky="nsew")
+        self._refresh_label_list()
+
+        button_frame = ttk.Frame(control_frame)
+        button_frame.grid(row=5, column=0, columnspan=2, pady=20)
+
+        ttk.Button(button_frame, text="擷取並儲存", command=self.capture_member).pack(side="left", padx=5)
+        ttk.Button(button_frame, text="清除", command=self._clear_form).pack(side="left", padx=5)
+        ttk.Button(button_frame, text="退出", command=self.quit).pack(side="left", padx=5)
+
+        self.status_var = tk.StringVar(value="就緒")
+        status_label = ttk.Label(self.root, textvariable=self.status_var, relief=tk.SUNKEN, anchor="w")
+        status_label.grid(row=1, column=0, columnspan=2, sticky="ew", padx=10, pady=(0, 10))
+
+    # ------------------------------------------------------------------
+    def _refresh_label_list(self) -> None:
+        self.label_list.delete(0, tk.END)
+        for label in self.dataset_manager.existing_labels():
+            self.label_list.insert(tk.END, label)
+
+    # ------------------------------------------------------------------
+    def _clear_form(self) -> None:
+        self.name_var.set("")
+        self.gender_var.set("")
+        self.age_var.set("")
+        self.email_var.set("")
+        self.status_var.set("就緒")
+
+    # ------------------------------------------------------------------
+    def _update_camera_frame(self) -> None:
+        if self.camera and self.camera.isOpened():
+            ret, frame = self.camera.read()
+            if ret:
+                self.current_frame = frame
+                rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                face_locations = face_recognition.face_locations(rgb_frame)
+                display_frame = frame.copy()
+                for top, right, bottom, left in face_locations:
+                    cv2.rectangle(display_frame, (left, top), (right, bottom), (0, 255, 0), 2)
+                image = Image.fromarray(cv2.cvtColor(display_frame, cv2.COLOR_BGR2RGB))
+                photo = ImageTk.PhotoImage(image=image)
+                self.video_label.configure(image=photo)
+                self.video_label.image = photo
+        self.root.after(40, self._update_camera_frame)
+
+    # ------------------------------------------------------------------
+    def capture_member(self) -> None:
+        name = self.name_var.get().strip()
+        if not name:
+            messagebox.showerror("錯誤", "請輸入會員姓名")
+            return
+        if self.current_frame is None:
+            messagebox.showerror("錯誤", "尚未取得攝影機影像")
+            return
+
+        self.status_var.set("處理中...")
+        self.root.update_idletasks()
+
+        rgb_frame = cv2.cvtColor(self.current_frame, cv2.COLOR_BGR2RGB)
+        face_locations = face_recognition.face_locations(rgb_frame)
+        if not face_locations:
+            messagebox.showerror("錯誤", "未偵測到人臉，請重新調整位置")
+            self.status_var.set("未偵測到人臉")
+            return
+        if len(face_locations) > 1:
+            messagebox.showwarning("警告", "偵測到多張人臉，僅使用最清晰的一張")
+
+        face_encodings = face_recognition.face_encodings(rgb_frame, known_face_locations=face_locations)
+        encoding_vector = face_encodings[0]
+
+        image_path = self.dataset_manager.save_face_image(name, self.current_frame)
+        record = FaceEncodingRecord(label=name, file_path=str(image_path), encoding=encoding_vector.tolist())
+        self.dataset_manager.append_encoding(record)
+
+        member = MemberInfo(
+            name=name,
+            gender=self.gender_var.get() or None,
+            age_group=self.age_var.get() or None,
+            email=self.email_var.get() or None,
+        )
+
+        member_id = self.db_manager.insert_member(member, record) if self.db_manager else None
+
+        if member_id is not None:
+            message = f"會員 {name} 註冊成功！ID: {member_id}"
+        else:
+            message = f"會員 {name} 已儲存（本地模式）"
+        self.status_var.set(message)
+        messagebox.showinfo("成功", message)
+        self._refresh_label_list()
+        self._clear_form()
+
+    # ------------------------------------------------------------------
+    def quit(self) -> None:
+        if self.camera and self.camera.isOpened():
+            self.camera.release()
+        self.db_manager.close()
+        self.root.destroy()
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        self.root.protocol("WM_DELETE_WINDOW", self.quit)
+        self.root.mainloop()
+
+
+def main() -> None:
+    app = FaceRegistrationApp()
+    app.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - GUI 入口點
+    main()

--- a/rollcall_edge.py
+++ b/rollcall_edge.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""rollcall_edge.py - 邊緣運算點名系統
+
+結合人臉辨識、MQTT 與圖形化介面，適用於樹莓派等邊緣裝置，
+可即時辨識進出人員並同步資料至資料庫與雲端平台。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import cv2
+import face_recognition
+import numpy as np
+from PIL import Image, ImageTk
+
+try:  # MQTT 為選用元件
+    import paho.mqtt.client as mqtt
+except Exception:  # pragma: no cover - 測試環境無法驗證
+    mqtt = None  # type: ignore[assignment]
+
+try:
+    import mysql.connector
+except Exception:  # pragma: no cover - 測試環境無法驗證
+    mysql = None  # type: ignore[assignment]
+else:  # pragma: no cover
+    mysql = mysql.connector
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from facegen import FaceEncodingGenerator
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = Path("config.json")
+ENCODINGS_CSV = Path("encodings.csv")
+
+
+@dataclass
+class RecognizedFace:
+    name: str
+    location: Tuple[int, int, int, int]
+    distance: float
+
+    @property
+    def confidence(self) -> float:
+        return float(np.clip(1.0 - self.distance, 0.0, 1.0))
+
+
+@dataclass
+class AttendanceRecord:
+    name: str
+    confidence: float
+    timestamp: datetime
+    member_id: Optional[int] = None
+    status: str = "present"
+
+    def to_payload(self) -> dict:
+        return {
+            "name": self.name,
+            "confidence": self.confidence,
+            "timestamp": self.timestamp.isoformat(),
+            "member_id": self.member_id,
+            "status": self.status,
+        }
+
+
+class FaceRecognitionEngine:
+    """封裝人臉辨識流程，提供辨識與繪製標註功能。"""
+
+    def __init__(self, csv_path: Path, tolerance: float, model: str, scale: float) -> None:
+        self.csv_path = csv_path
+        self.tolerance = tolerance
+        self.model = model
+        self.scale = max(0.1, min(scale, 1.0))
+        self.known_encodings: List[np.ndarray] = []
+        self.known_labels: List[str] = []
+        self._load_encodings()
+
+    def _load_encodings(self) -> None:
+        self.known_encodings.clear()
+        self.known_labels.clear()
+        if not self.csv_path.exists():
+            LOGGER.warning("找不到編碼檔 %s，請先使用 facegen.py 產生", self.csv_path)
+            return
+        records = FaceEncodingGenerator.load_from_csv(self.csv_path)
+        for record in records:
+            self.known_encodings.append(np.array(record.encoding, dtype="float32"))
+            self.known_labels.append(record.label)
+        LOGGER.info("載入 %d 筆已知人臉資料", len(self.known_labels))
+
+    def recognize(self, frame: np.ndarray) -> List[RecognizedFace]:
+        small_frame = cv2.resize(frame, (0, 0), fx=self.scale, fy=self.scale)
+        rgb_small = cv2.cvtColor(small_frame, cv2.COLOR_BGR2RGB)
+        locations = face_recognition.face_locations(rgb_small, model=self.model)
+        encodings = face_recognition.face_encodings(rgb_small, locations)
+        results: List[RecognizedFace] = []
+        for (top, right, bottom, left), encoding in zip(locations, encodings):
+            if not self.known_encodings:
+                name = "Unknown"
+                distance = 1.0
+            else:
+                distances = face_recognition.face_distance(self.known_encodings, encoding)
+                best_index = int(np.argmin(distances))
+                distance = float(distances[best_index])
+                name = self.known_labels[best_index] if distance <= self.tolerance else "Unknown"
+            scale_factor = 1.0 / self.scale
+            results.append(
+                RecognizedFace(
+                    name=name,
+                    distance=distance,
+                    location=(
+                        int(top * scale_factor),
+                        int(right * scale_factor),
+                        int(bottom * scale_factor),
+                        int(left * scale_factor),
+                    ),
+                )
+            )
+        return results
+
+    @staticmethod
+    def draw(frame: np.ndarray, results: Iterable[RecognizedFace]) -> np.ndarray:
+        annotated = frame.copy()
+        for result in results:
+            top, right, bottom, left = result.location
+            cv2.rectangle(annotated, (left, top), (right, bottom), (0, 128, 255), 2)
+            label = f"{result.name} ({result.confidence*100:.1f}%)"
+            cv2.rectangle(annotated, (left, bottom - 25), (right, bottom), (0, 128, 255), cv2.FILLED)
+            cv2.putText(
+                annotated,
+                label,
+                (left + 6, bottom - 8),
+                cv2.FONT_HERSHEY_DUPLEX,
+                0.5,
+                (255, 255, 255),
+                1,
+            )
+        return annotated
+
+
+class DatabaseManager:
+    """管理資料庫連線與考勤紀錄寫入。"""
+
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.connection: Optional[mysql.connection.MySQLConnection] = None  # type: ignore[attr-defined]
+        self.member_lookup: Dict[str, int] = {}
+        self.device_id = config.get("device", {}).get("id", "edge-node")
+
+    def connect(self) -> None:
+        if mysql is None:
+            LOGGER.warning("未安裝 mysql-connector-python，資料僅儲存在記憶體")
+            return
+        db_config = self.config.get("database")
+        if not db_config:
+            LOGGER.info("未設定資料庫連線，跳過")
+            return
+        try:
+            self.connection = mysql.connect(**db_config)
+            self._ensure_tables()
+            self.refresh_member_lookup()
+            LOGGER.info("資料庫連線成功")
+        except Exception as exc:  # pragma: no cover - 實際連線錯誤難以模擬
+            LOGGER.error("資料庫連線失敗: %s", exc)
+            self.connection = None
+
+    def close(self) -> None:
+        if self.connection:
+            self.connection.close()
+            self.connection = None
+
+    def _ensure_tables(self) -> None:
+        if not self.connection:
+            return
+        cursor = self.connection.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS attendance_log (
+                log_id INT PRIMARY KEY AUTO_INCREMENT,
+                member_id INT NULL,
+                name VARCHAR(100) NOT NULL,
+                confidence FLOAT,
+                status VARCHAR(20) DEFAULT 'present',
+                device_id VARCHAR(100),
+                captured_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (member_id) REFERENCES members(member_id) ON DELETE SET NULL
+            )
+            """
+        )
+        self.connection.commit()
+        cursor.close()
+
+    def refresh_member_lookup(self) -> None:
+        if not self.connection:
+            return
+        cursor = self.connection.cursor()
+        cursor.execute("SELECT member_id, name FROM members WHERE is_active = TRUE")
+        self.member_lookup = {name: member_id for member_id, name in cursor.fetchall()}
+        cursor.close()
+
+    def resolve_member_id(self, name: str) -> Optional[int]:
+        return self.member_lookup.get(name)
+
+    def log_attendance(self, record: AttendanceRecord) -> None:
+        if not self.connection:
+            return
+        cursor = self.connection.cursor()
+        query = (
+            "INSERT INTO attendance_log (member_id, name, confidence, status, device_id) "
+            "VALUES (%s, %s, %s, %s, %s)"
+        )
+        cursor.execute(
+            query,
+            (
+                record.member_id,
+                record.name,
+                record.confidence,
+                record.status,
+                self.device_id,
+            ),
+        )
+        self.connection.commit()
+        cursor.close()
+
+
+class MQTTClient:
+    """管理 MQTT 發佈的輔助類別。"""
+
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.client: Optional[mqtt.Client] = None  # type: ignore[type-arg]
+        self.topic = config.get("mqtt", {}).get("topic", "face_ad_system/attendance")
+
+    def connect(self) -> None:
+        if mqtt is None:
+            LOGGER.warning("未安裝 paho-mqtt，將停用 MQTT 功能")
+            return
+        mqtt_config = self.config.get("mqtt")
+        if not mqtt_config:
+            LOGGER.info("未設定 MQTT 參數，跳過")
+            return
+        self.client = mqtt.Client()
+        if username := mqtt_config.get("username"):
+            self.client.username_pw_set(username, mqtt_config.get("password"))
+        try:
+            self.client.connect(mqtt_config.get("host", "localhost"), mqtt_config.get("port", 1883))
+            self.client.loop_start()
+            LOGGER.info("MQTT 連線成功：%s", mqtt_config.get("host"))
+        except Exception as exc:  # pragma: no cover
+            LOGGER.error("MQTT 連線失敗: %s", exc)
+            self.client = None
+
+    def publish_attendance(self, record: AttendanceRecord) -> None:
+        if not self.client:
+            return
+        payload = json.dumps(record.to_payload())
+        try:
+            self.client.publish(self.topic, payload, qos=1)
+        except Exception as exc:  # pragma: no cover
+            LOGGER.error("MQTT 發佈失敗: %s", exc)
+
+    def close(self) -> None:
+        if self.client:
+            self.client.loop_stop()
+            self.client.disconnect()
+            self.client = None
+
+
+class RollCallEdgeApp:
+    """結合 GUI 與人臉辨識的點名系統。"""
+
+    def __init__(
+        self,
+        config_path: Path = DEFAULT_CONFIG_PATH,
+        encodings_csv: Path = ENCODINGS_CSV,
+        tolerance: float = 0.6,
+        model: str = "hog",
+        scale: float = 0.25,
+        frame_skip: int = 2,
+        cooldown: int = 30,
+    ) -> None:
+        logging.basicConfig(level=logging.INFO)
+        self.config = self._load_config(config_path)
+
+        self.db_manager = DatabaseManager(self.config)
+        self.db_manager.connect()
+        self.mqtt_client = MQTTClient(self.config)
+        self.mqtt_client.connect()
+
+        self.engine = FaceRecognitionEngine(encodings_csv, tolerance, model, scale)
+        self.frame_skip = max(1, frame_skip)
+        self.cooldown = timedelta(seconds=max(1, cooldown))
+        self.last_seen: Dict[str, datetime] = {}
+        self.recognized_count = 0
+        self.unknown_count = 0
+
+        self.camera = self._open_camera()
+        self.frame_index = 0
+
+        self.root = tk.Tk()
+        self.root.title("智慧點名系統")
+        self.root.geometry("1200x720")
+
+        self._build_gui()
+        self._update_loop()
+
+    # ------------------------------------------------------------------
+    def _load_config(self, path: Path) -> dict:
+        if not path.exists():
+            LOGGER.warning("找不到設定檔 %s，將使用預設值", path)
+            return {}
+        with path.open("r", encoding="utf-8") as fp:
+            return json.load(fp)
+
+    # ------------------------------------------------------------------
+    def _open_camera(self) -> cv2.VideoCapture:
+        camera_config = self.config.get("camera", {})
+        capture = cv2.VideoCapture(camera_config.get("index", 0))
+        if capture.isOpened():
+            if width := camera_config.get("width"):
+                capture.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+            if height := camera_config.get("height"):
+                capture.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+            if fps := camera_config.get("fps"):
+                capture.set(cv2.CAP_PROP_FPS, fps)
+        else:
+            messagebox.showerror("攝影機錯誤", "無法開啟攝影機，請確認裝置連線")
+        return capture
+
+    # ------------------------------------------------------------------
+    def _build_gui(self) -> None:
+        self.root.columnconfigure(0, weight=3)
+        self.root.columnconfigure(1, weight=2)
+        self.root.rowconfigure(0, weight=1)
+
+        preview_frame = ttk.LabelFrame(self.root, text="即時畫面", padding=10)
+        preview_frame.grid(row=0, column=0, sticky="nsew", padx=10, pady=10)
+        self.video_label = ttk.Label(preview_frame)
+        self.video_label.pack(fill="both", expand=True)
+
+        side_frame = ttk.Frame(self.root, padding=10)
+        side_frame.grid(row=0, column=1, sticky="nsew")
+        side_frame.columnconfigure(0, weight=1)
+        side_frame.rowconfigure(1, weight=1)
+
+        status_frame = ttk.LabelFrame(side_frame, text="狀態", padding=10)
+        status_frame.grid(row=0, column=0, sticky="ew")
+        self.status_var = tk.StringVar()
+        self._update_status()
+        ttk.Label(status_frame, textvariable=self.status_var, anchor="w").pack(fill="x")
+
+        log_frame = ttk.LabelFrame(side_frame, text="點名記錄", padding=10)
+        log_frame.grid(row=1, column=0, sticky="nsew", pady=10)
+        columns = ("time", "name", "confidence", "status")
+        self.tree = ttk.Treeview(log_frame, columns=columns, show="headings", height=15)
+        for col, label in zip(columns, ("時間", "姓名", "信心度", "狀態")):
+            self.tree.heading(col, text=label)
+            self.tree.column(col, width=120, anchor="center")
+        scrollbar = ttk.Scrollbar(log_frame, orient=tk.VERTICAL, command=self.tree.yview)
+        self.tree.configure(yscrollcommand=scrollbar.set)
+        self.tree.pack(side=tk.LEFT, fill="both", expand=True)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+
+        stats_frame = ttk.Frame(side_frame)
+        stats_frame.grid(row=2, column=0, sticky="ew")
+        self.stats_var = tk.StringVar()
+        self._update_stats()
+        ttk.Label(stats_frame, textvariable=self.stats_var, anchor="w").pack(fill="x")
+
+        control_frame = ttk.Frame(side_frame)
+        control_frame.grid(row=3, column=0, sticky="ew", pady=(10, 0))
+        ttk.Button(control_frame, text="重新載入資料", command=self._reload_data).pack(side=tk.LEFT, padx=5)
+        ttk.Button(control_frame, text="退出", command=self.quit).pack(side=tk.LEFT, padx=5)
+
+    # ------------------------------------------------------------------
+    def _update_status(self) -> None:
+        db_status = "已連線" if self.db_manager.connection else "離線"
+        mqtt_status = "已連線" if self.mqtt_client.client else "離線"
+        self.status_var.set(f"資料庫: {db_status} | MQTT: {mqtt_status}")
+
+    # ------------------------------------------------------------------
+    def _update_stats(self) -> None:
+        self.stats_var.set(f"已點名: {self.recognized_count} 人 | 未知: {self.unknown_count}")
+
+    # ------------------------------------------------------------------
+    def _reload_data(self) -> None:
+        self.db_manager.refresh_member_lookup()
+        self.engine._load_encodings()
+        self._update_status()
+        messagebox.showinfo("已重新載入", "已更新會員資料與人臉編碼")
+
+    # ------------------------------------------------------------------
+    def _update_loop(self) -> None:
+        if self.camera and self.camera.isOpened():
+            ret, frame = self.camera.read()
+            if ret:
+                self.frame_index += 1
+                if self.frame_index % self.frame_skip == 0:
+                    results = self.engine.recognize(frame)
+                    self._handle_recognition(results)
+                    annotated = FaceRecognitionEngine.draw(frame, results)
+                else:
+                    annotated = frame
+                image = Image.fromarray(cv2.cvtColor(annotated, cv2.COLOR_BGR2RGB))
+                photo = ImageTk.PhotoImage(image=image)
+                self.video_label.configure(image=photo)
+                self.video_label.image = photo
+        self.root.after(30, self._update_loop)
+
+    # ------------------------------------------------------------------
+    def _handle_recognition(self, results: Iterable[RecognizedFace]) -> None:
+        now = datetime.now()
+        for result in results:
+            if result.name == "Unknown":
+                self.unknown_count += 1
+                continue
+            last_seen = self.last_seen.get(result.name)
+            if last_seen and now - last_seen < self.cooldown:
+                continue
+            member_id = self.db_manager.resolve_member_id(result.name)
+            record = AttendanceRecord(
+                name=result.name,
+                confidence=result.confidence,
+                timestamp=now,
+                member_id=member_id,
+            )
+            self.last_seen[result.name] = now
+            self.recognized_count += 1
+            self._append_record(record)
+            self.db_manager.log_attendance(record)
+            self.mqtt_client.publish_attendance(record)
+        self._update_stats()
+
+    # ------------------------------------------------------------------
+    def _append_record(self, record: AttendanceRecord) -> None:
+        self.tree.insert(
+            "",
+            0,
+            values=(
+                record.timestamp.strftime("%H:%M:%S"),
+                record.name,
+                f"{record.confidence*100:.1f}%",
+                record.status,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    def quit(self) -> None:
+        if self.camera and self.camera.isOpened():
+            self.camera.release()
+        self.db_manager.close()
+        self.mqtt_client.close()
+        self.root.destroy()
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        self.root.protocol("WM_DELETE_WINDOW", self.quit)
+        self.root.mainloop()
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="邊緣點名系統")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="系統設定檔")
+    parser.add_argument("--encodings", default=str(ENCODINGS_CSV), help="人臉編碼 CSV")
+    parser.add_argument("--tolerance", type=float, default=0.6, help="人臉辨識容忍度")
+    parser.add_argument("--model", choices=["hog", "cnn"], default="hog", help="人臉偵測模型")
+    parser.add_argument("--scale", type=float, default=0.25, help="影像縮放比例")
+    parser.add_argument("--frame-skip", type=int, default=2, help="辨識時跳過的影格數")
+    parser.add_argument("--cooldown", type=int, default=30, help="同一人員再次點名的冷卻時間（秒）")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+
+    app = RollCallEdgeApp(
+        config_path=Path(args.config),
+        encodings_csv=Path(args.encodings),
+        tolerance=args.tolerance,
+        model=args.model,
+        scale=args.scale,
+        frame_skip=args.frame_skip,
+        cooldown=args.cooldown,
+    )
+    app.run()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - GUI 入口點
+    raise SystemExit(main())

--- a/tests/test_compile_modules.py
+++ b/tests/test_compile_modules.py
@@ -1,0 +1,21 @@
+import compileall
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+MODULES = [
+    "facegen.py",
+    "facecam.py",
+    "faceme.py",
+    "rollcall_edge.py",
+    "face_recognition_ad_system.py",
+    "face_register.py",
+    "ad_manager.py",
+]
+
+
+def test_project_sources_compile():
+    for module in MODULES:
+        target = PROJECT_ROOT / module
+        assert target.exists(), f"{module} 檔案不存在"
+        compiled = compileall.compile_file(str(target), force=True, quiet=1)
+        assert compiled, f"{module} 編譯失敗"

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,128 @@
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _install_stub(module_name: str, module):
+    if module_name not in sys.modules:
+        sys.modules[module_name] = module
+
+
+_install_stub('cv2', MagicMock())
+_install_stub('face_recognition', MagicMock())
+numpy_module = ModuleType('numpy')
+numpy_module.bool_ = bool
+numpy_module.isscalar = lambda value: isinstance(value, (int, float, bool))
+_install_stub('numpy', numpy_module)
+
+mysql_connector = MagicMock()
+mysql_package = ModuleType('mysql')
+mysql_package.connector = mysql_connector
+_install_stub('mysql', mysql_package)
+_install_stub('mysql.connector', mysql_connector)
+
+pil_package = ModuleType('PIL')
+pil_image = MagicMock()
+pil_imagetk = MagicMock()
+pil_package.Image = pil_image
+pil_package.ImageTk = pil_imagetk
+_install_stub('PIL', pil_package)
+_install_stub('PIL.Image', pil_image)
+_install_stub('PIL.ImageTk', pil_imagetk)
+
+tk_module = MagicMock()
+ttk_module = MagicMock()
+_install_stub('tkinter', tk_module)
+_install_stub('tkinter.ttk', ttk_module)
+
+from face_recognition_ad_system import FaceRecognitionAdSystem
+
+
+@pytest.fixture(autouse=True)
+def reset_env():
+    """確保每次測試都在乾淨的環境變數狀態下執行。"""
+    original_environ = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(original_environ)
+
+
+def _build_system(monkeypatch, tmp_path: Path, env_content: str):
+    env_path = tmp_path / ".env"
+    env_path.write_text(env_content, encoding="utf-8")
+    monkeypatch.setenv("FACE_AD_ENV_FILE", str(env_path))
+    monkeypatch.setattr(FaceRecognitionAdSystem, "connect_database", lambda self: None)
+    monkeypatch.setattr(FaceRecognitionAdSystem, "load_face_data", lambda self: None)
+    monkeypatch.setattr(FaceRecognitionAdSystem, "init_camera", lambda self: None)
+    system = FaceRecognitionAdSystem()
+    return system, env_path
+
+
+def test_env_file_overrides_defaults(monkeypatch, tmp_path):
+    system, env_path = _build_system(
+        monkeypatch,
+        tmp_path,
+        """
+FACE_AD_DB_HOST=example.com
+FACE_AD_DB_USER=demo
+FACE_AD_DB_PASSWORD=secret
+FACE_AD_DB_NAME=demo_db
+FACE_AD_DB_PORT=13306
+FACE_AD_CAMERA_SOURCE=1
+FACE_AD_CAMERA_WIDTH=800
+FACE_AD_CAMERA_HEIGHT=600
+FACE_AD_CAMERA_FPS=25
+FACE_AD_RECOGNITION_TOLERANCE=0.45
+FACE_AD_RECOGNITION_MODEL=cnn
+"""
+    )
+
+    assert system.env_file_path == env_path
+    assert system.config["database"]["host"] == "example.com"
+    assert system.config["database"]["user"] == "demo"
+    assert system.config["database"]["password"] == "secret"
+    assert system.config["database"]["database"] == "demo_db"
+    assert system.config["database"]["port"] == 13306
+    assert system.config["camera"]["source"] == 1
+    assert system.config["camera"]["width"] == 800
+    assert system.config["camera"]["height"] == 600
+    assert system.config["camera"]["fps"] == 25
+    assert system.config["recognition"]["tolerance"] == pytest.approx(0.45)
+    assert system.config["recognition"]["model"] == "cnn"
+
+
+def test_invalid_env_values_keep_defaults(monkeypatch, tmp_path):
+    system, _ = _build_system(
+        monkeypatch,
+        tmp_path,
+        """
+FACE_AD_CAMERA_WIDTH=invalid
+FACE_AD_CAMERA_HEIGHT=oops
+FACE_AD_CAMERA_FPS=broken
+FACE_AD_RECOGNITION_TOLERANCE=nan
+"""
+    )
+
+    assert system.config["camera"]["width"] == 640
+    assert system.config["camera"]["height"] == 480
+    assert system.config["camera"]["fps"] == 30
+    assert system.config["recognition"]["tolerance"] == pytest.approx(0.6)
+
+
+def test_camera_source_as_path(monkeypatch, tmp_path):
+    system, _ = _build_system(
+        monkeypatch,
+        tmp_path,
+        """
+FACE_AD_CAMERA_SOURCE=/dev/video1
+"""
+    )
+
+    assert system.config["camera"]["source"] == "/dev/video1"


### PR DESCRIPTION
## Summary
- extend the main face recognition controller to load optional values from a .env file without breaking defaults
- document the supported environment variables and provide convenient make test / pytest commands
- add pytest coverage that stubs heavy dependencies, verifies .env overrides, and ensures key modules compile

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cbd2105140832ebf37a8a9ee134b8a